### PR TITLE
Gibbs transform

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -262,6 +262,30 @@ Intensity
     :members:
     :special-members: __call__
 
+`GibbsNoise`
+""""""""""""""
+.. autoclass:: GibbsNoise
+    :members:
+    :special-members: __call__
+
+`RandGibbsNoise`
+""""""""""""""
+.. autoclass:: GibbsNoise
+    :members:
+    :special-members: __call__
+
+`GibbsNoised`
+""""""""""""""
+.. autoclass:: GibbsNoised
+    :members:
+    :special-members: __call__
+
+`RandGibbsNoised`
+""""""""""""""
+.. autoclass:: RandGibbsNoised
+    :members:
+    :special-members: __call__
+
 IO
 ^^
 

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -240,7 +240,11 @@ class StdShiftIntensity(Transform):
     """
 
     def __init__(
-        self, factor: float, nonzero: bool = False, channel_wise: bool = False, dtype: DtypeLike = np.float32,
+        self,
+        factor: float,
+        nonzero: bool = False,
+        channel_wise: bool = False,
+        dtype: DtypeLike = np.float32,
     ) -> None:
         self.factor = factor
         self.nonzero = nonzero
@@ -429,7 +433,11 @@ class RandBiasField(RandomizableTransform):
         self.dtype = dtype
 
     def _generate_random_field(
-        self, spatial_shape: Tuple[int, ...], rank: int, degree: int, coeff: Tuple[int, ...],
+        self,
+        spatial_shape: Tuple[int, ...],
+        rank: int,
+        degree: int,
+        coeff: Tuple[int, ...],
     ):
         """
         products of polynomials as bias field estimations
@@ -1155,12 +1163,7 @@ class RandGibbsNoise(RandomizableTransform):
         as_tensor_output: if true return torch.Tensor, else return np.array. default: True.
     """
 
-    def __init__(
-        self,
-        prob: float = 0.1,
-        alpha: Sequence[float] = [0.0, 1.0],
-        as_tensor_output: bool = True
-    ) -> None:
+    def __init__(self, prob: float = 0.1, alpha: Sequence[float] = (0.0, 1.0), as_tensor_output: bool = True) -> None:
 
         if len(alpha) != 2:
             raise AssertionError("alpha length must be 2.")
@@ -1240,7 +1243,9 @@ class GibbsNoise(Transform):
         Args:
             x (torch.Tensor): tensor to fourier transform.
         """
-        out: torch.Tensor = torch.fft.fftshift(torch.fft.fftn(x, dim=tuple(range(-n_dims, 0))), dim=tuple(range(-n_dims, 0)))
+        out: torch.Tensor = torch.fft.fftshift(
+            torch.fft.fftn(x, dim=tuple(range(-n_dims, 0))), dim=tuple(range(-n_dims, 0))
+        )
         return out
 
     def inv_shift_fourier(self, k: torch.Tensor, n_dims: int) -> torch.Tensor:
@@ -1271,7 +1276,7 @@ class GibbsNoise(Transform):
         coords = np.ogrid[tuple(slice(0, i) for i in shape)]
 
         # need to subtract center coord and then square for Euc distance
-        coords_from_center_sq = [(coord - c)**2 for coord, c in zip(coords, center)]
+        coords_from_center_sq = [(coord - c) ** 2 for coord, c in zip(coords, center)]
         dist_from_center = np.sqrt(sum(coords_from_center_sq))
         mask = dist_from_center <= r
 

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1185,8 +1185,13 @@ class RandGibbsNoise(RandomizableTransform):
 
         if self._do_transform:
             # apply transform
-            transform = GibbsNoise(self.sampled_alpha)
+            transform = GibbsNoise(self.sampled_alpha, self.as_tensor_output)
             img = transform(img)
+        else:
+            if isinstance(img, np.ndarray) and self.as_tensor_output:
+                img = torch.Tensor(img)
+            elif isinstance(img, torch.Tensor) and not self.as_tensor_output:
+                img = img.detach().cpu().numpy()
         return img
 
     def randomize(self, _: Any) -> None:

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -30,7 +30,6 @@ from monai.transforms.intensity.array import (
     MaskIntensity,
     NormalizeIntensity,
     RandBiasField,
-    RandGibbsNoise,
     RandRicianNoise,
     ScaleIntensity,
     ScaleIntensityRange,
@@ -1051,7 +1050,7 @@ class RandGibbsNoised(RandomizableTransform, MapTransform):
         self,
         keys: KeysCollection,
         prob: float = 0.1,
-        alpha: Sequence[float] = [0.0, 1.0],
+        alpha: Sequence[float] = (0.0, 1.0),
         as_tensor_output: bool = True,
         allow_missing_keys: bool = False,
     ) -> None:
@@ -1103,17 +1102,15 @@ class GibbsNoised(MapTransform):
     """
 
     def __init__(
-        self,
-        keys: KeysCollection,
-        alpha: float = 0.5,
-        as_tensor_output: bool = True,
-        allow_missing_keys: bool = False
+        self, keys: KeysCollection, alpha: float = 0.5, as_tensor_output: bool = True, allow_missing_keys: bool = False
     ) -> None:
 
         MapTransform.__init__(self, keys, allow_missing_keys)
         self.transform = GibbsNoise(alpha, as_tensor_output)
 
-    def __call__(self, data: Mapping[Hashable, Union[torch.Tensor, np.ndarray]]) -> Dict[Hashable, Union[torch.Tensor, np.ndarray]]:
+    def __call__(
+        self, data: Mapping[Hashable, Union[torch.Tensor, np.ndarray]]
+    ) -> Dict[Hashable, Union[torch.Tensor, np.ndarray]]:
 
         d = dict(data)
         for key in self.key_iterator(d):

--- a/tests/test_gibbs_noise.py
+++ b/tests/test_gibbs_noise.py
@@ -9,16 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from monai.utils.misc import set_determinism
-from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 import unittest
+from copy import deepcopy
 
 import numpy as np
 import torch
-from copy import deepcopy
 from parameterized import parameterized
 
+from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 from monai.transforms import GibbsNoise
+from monai.utils.misc import set_determinism
 
 TEST_CASES = []
 for shape in ((128, 64), (64, 48, 80)):
@@ -49,6 +49,7 @@ class TestGibbsNoise(unittest.TestCase):
         out1 = t(deepcopy(im))
         out2 = t(deepcopy(im))
         np.testing.assert_allclose(out1, out2)
+        self.assertIsInstance(out1, torch.Tensor if as_tensor_output else np.ndarray)
 
     @parameterized.expand(TEST_CASES)
     def test_identity(self, im_shape, _, as_tensor_input):

--- a/tests/test_gibbs_noised.py
+++ b/tests/test_gibbs_noised.py
@@ -9,16 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from monai.utils.misc import set_determinism
-from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 import unittest
+from copy import deepcopy
 
 import numpy as np
 import torch
-from copy import deepcopy
 from parameterized import parameterized
 
+from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 from monai.transforms import GibbsNoised
+from monai.utils.misc import set_determinism
 
 TEST_CASES = []
 for shape in ((128, 64), (64, 48, 80)):
@@ -27,6 +27,7 @@ for shape in ((128, 64), (64, 48, 80)):
             TEST_CASES.append((shape, as_tensor_output, as_tensor_input))
 
 KEYS = ["im", "label"]
+
 
 class TestGibbsNoised(unittest.TestCase):
     def setUp(self):
@@ -52,6 +53,7 @@ class TestGibbsNoised(unittest.TestCase):
         out2 = t(deepcopy(data))
         for k in KEYS:
             np.testing.assert_allclose(out1[k], out2[k])
+            self.assertIsInstance(out1[k], torch.Tensor if as_tensor_output else np.ndarray)
 
     @parameterized.expand(TEST_CASES)
     def test_identity(self, im_shape, _, as_tensor_input):

--- a/tests/test_rand_gibbs_noise.py
+++ b/tests/test_rand_gibbs_noise.py
@@ -9,69 +9,82 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from monai.utils.misc import set_determinism
+from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 import unittest
 
 import numpy as np
 import torch
+from copy import deepcopy
+from parameterized import parameterized
 
 from monai.transforms import RandGibbsNoise
-from tests.utils import TorchImageTestCase2D, TorchImageTestCase3D
+
+TEST_CASES = []
+for shape in ((128, 64), (64, 48, 80)):
+    for as_tensor_output in (True, False):
+        for as_tensor_input in (True, False):
+            TEST_CASES.append((shape, as_tensor_output, as_tensor_input))
 
 
-class TestRandGibbsNoise(TorchImageTestCase3D, TorchImageTestCase2D):
-    """
-    Tests below check the extreme cases of the transform.
-    It should act as identity for alpha = 0 and as the zero
-    map for alpha = 1. The functions check the 2D and 3D cases.
-    We also check the case when alpha is a list.
-    """
+class TestRandGibbsNoise(unittest.TestCase):
+    def setUp(self):
+        set_determinism(0)
+        super().setUp()
 
-    def test_correct_results(self):
-        # check both 3d and 2d cases
-        self.test_3d()
-        self.test_2d()
+    def tearDown(self):
+        set_determinism(None)
 
-    def test_3d(self):
+    @staticmethod
+    def get_data(im_shape, as_tensor_input):
+        create_test_image = create_test_image_2d if len(im_shape) == 2 else create_test_image_3d
+        im = create_test_image(*im_shape, 4, 20, 0, 5)[0][None]
+        return torch.Tensor(im) if as_tensor_input else im
 
-        TorchImageTestCase3D.setUp(self)
+    @parameterized.expand(TEST_CASES)
+    def test_0_prob(self, im_shape, as_tensor_output, as_tensor_input):
+        im = self.get_data(im_shape, as_tensor_input)
+        alpha = [0.5, 1.0]
+        t = RandGibbsNoise(0.0, alpha, as_tensor_output)
+        out = t(im)
+        np.testing.assert_allclose(im, out)
 
-        # check identity
-        id_map = RandGibbsNoise(prob=1, alpha=0)
-        new = id_map(self.imt)
-        np.testing.assert_allclose(self.imt, new, atol=1e-3)
+    @parameterized.expand(TEST_CASES)
+    def test_same_result(self, im_shape, as_tensor_output, as_tensor_input):
+        im = self.get_data(im_shape, as_tensor_input)
+        alpha = [0.5, 0.8]
+        t = RandGibbsNoise(1.0, alpha, as_tensor_output)
+        t.set_random_state(42)
+        out1 = t(deepcopy(im))
+        t.set_random_state(42)
+        out2 = t(deepcopy(im))
+        np.testing.assert_allclose(out1, out2)
 
-        # check zero vector
-        zero_map = RandGibbsNoise(prob=1, alpha=1)
-        new = zero_map(self.imt)
-        np.testing.assert_allclose(0 * self.imt, new)
+    @parameterized.expand(TEST_CASES)
+    def test_identity(self, im_shape, _, as_tensor_input):
+        im = self.get_data(im_shape, as_tensor_input)
+        alpha = [0.0, 0.0]
+        t = RandGibbsNoise(1.0, alpha)
+        out = t(deepcopy(im))
+        np.testing.assert_allclose(im, out, atol=1e-2)
 
-        # check alpha = [a,b] works
-        g = RandGibbsNoise(prob=1.0, alpha=[0.50, 0.51])
-        new = g(self.imt)
-        self.assertTrue(
-            (g.sampled_alpha >= 0.50 and g.sampled_alpha <= 0.51), "sampling alpha outside provided interval"
-        )
+    @parameterized.expand(TEST_CASES)
+    def test_alpha_1(self, im_shape, _, as_tensor_input):
+        im = self.get_data(im_shape, as_tensor_input)
+        alpha = [1.0, 1.0]
+        t = RandGibbsNoise(1.0, alpha)
+        out = t(deepcopy(im))
+        np.testing.assert_allclose(0 * im, out)
 
-    def test_2d(self):
+    @parameterized.expand(TEST_CASES)
+    def test_alpha(self, im_shape, _, as_tensor_input):
+        im = self.get_data(im_shape, as_tensor_input)
+        alpha = [0.5, 0.51]
+        t = RandGibbsNoise(1.0, alpha)
+        _ = t(deepcopy(im))
+        self.assertGreaterEqual(t.sampled_alpha, 0.5)
+        self.assertLessEqual(t.sampled_alpha, 0.51)
 
-        TorchImageTestCase2D.setUp(self)
-
-        # check identity
-        id_map = RandGibbsNoise(prob=1, alpha=0, dim=2)
-        new = id_map(self.imt)
-        np.testing.assert_allclose(self.imt, new, atol=1e-3)
-
-        # check zero vector
-        zero_map = RandGibbsNoise(prob=1, alpha=1, dim=2)
-        new = zero_map(self.imt)
-        np.testing.assert_allclose(0 * self.imt, new)
-
-        # check alpha = [a,b] works
-        g = RandGibbsNoise(prob=1.0, alpha=[0.50, 0.51], dim=2)
-        new = g(self.imt)
-        self.assertTrue(
-            (g.sampled_alpha >= 0.50 and g.sampled_alpha <= 0.51), "sampling alpha outside provided interval"
-        )
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_gibbs_noise.py
+++ b/tests/test_rand_gibbs_noise.py
@@ -9,16 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from monai.utils.misc import set_determinism
-from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 import unittest
+from copy import deepcopy
 
 import numpy as np
 import torch
-from copy import deepcopy
 from parameterized import parameterized
 
+from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 from monai.transforms import RandGibbsNoise
+from monai.utils.misc import set_determinism
 
 TEST_CASES = []
 for shape in ((128, 64), (64, 48, 80)):
@@ -59,6 +59,7 @@ class TestRandGibbsNoise(unittest.TestCase):
         t.set_random_state(42)
         out2 = t(deepcopy(im))
         np.testing.assert_allclose(out1, out2)
+        self.assertIsInstance(out1, torch.Tensor if as_tensor_output else np.ndarray)
 
     @parameterized.expand(TEST_CASES)
     def test_identity(self, im_shape, _, as_tensor_input):
@@ -84,7 +85,6 @@ class TestRandGibbsNoise(unittest.TestCase):
         _ = t(deepcopy(im))
         self.assertGreaterEqual(t.sampled_alpha, 0.5)
         self.assertLessEqual(t.sampled_alpha, 0.51)
-
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_gibbs_noised.py
+++ b/tests/test_rand_gibbs_noised.py
@@ -9,16 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from monai.utils.misc import set_determinism
-from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 import unittest
+from copy import deepcopy
 
 import numpy as np
 import torch
-from copy import deepcopy
 from parameterized import parameterized
 
+from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 from monai.transforms import RandGibbsNoised
+from monai.utils.misc import set_determinism
 
 TEST_CASES = []
 for shape in ((128, 64), (64, 48, 80)):
@@ -27,6 +27,7 @@ for shape in ((128, 64), (64, 48, 80)):
             TEST_CASES.append((shape, as_tensor_output, as_tensor_input))
 
 KEYS = ["im", "label"]
+
 
 class TestRandGibbsNoised(unittest.TestCase):
     def setUp(self):
@@ -63,6 +64,7 @@ class TestRandGibbsNoised(unittest.TestCase):
         out2 = t(deepcopy(data))
         for k in KEYS:
             np.testing.assert_allclose(out1[k], out2[k])
+            self.assertIsInstance(out1[k], torch.Tensor if as_tensor_output else np.ndarray)
 
     @parameterized.expand(TEST_CASES)
     def test_identity(self, im_shape, _, as_tensor_input):
@@ -91,7 +93,6 @@ class TestRandGibbsNoised(unittest.TestCase):
         t = RandGibbsNoised(KEYS, 1.0, alpha)
         out = t(deepcopy(data))
         np.testing.assert_allclose(out[KEYS[0]], out[KEYS[1]])
-
 
     @parameterized.expand(TEST_CASES)
     def test_alpha(self, im_shape, _, as_tensor_input):


### PR DESCRIPTION
some suggested changes.

1. try and increase re-used code (so checks on alpha only in array transforms, no longer needed in dictionary versions.
2. a bit more testing
3. slightly more succinct mask calculation
4. Deterministic only accepts float alpha, random only accepts `Sequence[float]` with length==2.
5. Calculate number of dimensions based on the image passed into `__call__`.
6. allow input to be numpy array (some input images will be numpy)
7. option to return output as either torch.tensor or numpy.array (majority of transforms expect numpy input, so numpy output here makes most sense).